### PR TITLE
Remove error crate due to securty vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ travis-ci = { repository = "althea-mesh/serde-rlp", branch = "master" }
 [dependencies]
 byteorder = "1.2"
 num = "0.2"
-error = "0.1"
 serde = "1.0.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0.0"
-serde_bytes = "0.10"
+serde_bytes = "0.11"

--- a/src/de.rs
+++ b/src/de.rs
@@ -416,7 +416,8 @@ fn deserialize_set_representation_of_three() {
 fn deserialize_three_levels() {
     let foo: Vec<Vec<Vec<String>>> = from_bytes(&[
         0xca, 0xc9, 0xc8, 0x83, 0x61, 0x62, 0x63, 0x83, 0x64, 0x65, 0x66,
-    ]).unwrap();
+    ])
+    .unwrap();
     assert_eq!(foo, [[["abc", "def"]]]);
 }
 
@@ -424,16 +425,6 @@ fn deserialize_three_levels() {
 #[should_panic]
 fn simple_invalid() {
     let _foo: String = from_bytes(&[0x83, 0x61, 0x62, 0x63, /* excess */ 0xff]).unwrap();
-}
-
-fn get_bytes(b: &str) -> Option<Vec<u8>> {
-    b.as_bytes()
-        .chunks(2)
-        .map(|ch| {
-            str::from_utf8(&ch)
-                .ok()
-                .and_then(|res| u8::from_str_radix(&res, 16).ok())
-        }).collect()
 }
 
 #[test]
@@ -454,7 +445,8 @@ fn lorem_ipsum() {
         0x6f, 0x6c, 0x6f, 0x72, 0x20, 0x73, 0x69, 0x74, 0x20, 0x61, 0x6d, 0x65, 0x74, 0x2c, 0x20,
         0x63, 0x6f, 0x6e, 0x73, 0x65, 0x63, 0x74, 0x65, 0x74, 0x75, 0x72, 0x20, 0x61, 0x64, 0x69,
         0x70, 0x69, 0x73, 0x69, 0x63, 0x69, 0x6e, 0x67, 0x20, 0x65, 0x6c, 0x69, 0x74,
-    ]).unwrap();
+    ])
+    .unwrap();
     assert_eq!(
         data,
         "Lorem ipsum dolor sit amet, consectetur adipisicing elit"

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use serde::{de, ser};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum Error {
     Message(String),
     TrailingBytes,
@@ -40,13 +40,7 @@ impl de::Error for Error {
 
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(std::error::Error::description(self))
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
+        let s = match *self {
             Error::Message(ref msg) => msg,
             Error::TrailingBytes => "Trailing bytes found at the end of input",
             Error::EmptyBuffer => "Empty buffer detected",
@@ -56,6 +50,7 @@ impl std::error::Error for Error {
             Error::ExpectedString => "Expected string",
             Error::InvalidString => "Unable to decode valid string",
             Error::WrongPrefix => "Wrong prefix",
-        }
+        };
+        formatter.write_str(s)
     }
 }


### PR DESCRIPTION
Converted over to the commonly used `thiserror` crate.

https://github.com/advisories/GHSA-j79j-cx3h-g27h

https://ossindex.sonatype.org/vulnerability/CVE-2020-35881?component-type=cargo&component-name=traitobject&utm_source=dependency-track&utm_medium=integration&utm_content=v4.5.0
